### PR TITLE
Switch PHPCS from the squizlabs to phpcsstandards package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "phpcompatibility/phpcompatibility-wp": "^2.1.2",
     "phpcsstandards/phpcsextra": "^1.0.2",
     "sirbrillig/phpcs-variable-analysis": "^v2.11.17",
-    "squizlabs/php_codesniffer": "^3.6.1",
+    "phpcsstandards/php_codesniffer": "^3.6.1",
     "wp-coding-standards/wpcs": "^3.0.0"
   },
   "require-dev": {


### PR DESCRIPTION
The squizlabs package comes from a repo with no active admins, and active maintenance moved to the PHPCS Standards org, this repo should use the new package, especially given there are already phpcsstandards packages in use here